### PR TITLE
Allow overrides to be used for unknown types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "fast-check-io-ts",
   "version": "0.4.0",
   "description": "io-ts codec to fast-check arbitrary mapping",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "repository": {
@@ -27,14 +25,7 @@
     "lint": "tslint -p tsconfig.json src/*.ts",
     "dtslint": "dtslint dtslint"
   },
-  "keywords": [
-    "fast-check",
-    "io-ts",
-    "typescript",
-    "arbitrary",
-    "generative",
-    "testing"
-  ],
+  "keywords": ["fast-check", "io-ts", "typescript", "arbitrary", "generative", "testing"],
   "author": "Giovanni Gonzaga <giovanni@buildo.io>",
   "license": "MIT",
   "devDependencies": {
@@ -49,12 +40,13 @@
     "rimraf": "^2.6.3",
     "ts-jest": "^24.0.2",
     "tslint": "^5.18.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.5.3",
+    "io-ts-types": "^0.5.6"
   },
   "peerDependencies": {
     "fast-check": "^1.16.0",
-    "io-ts": "^2.0.0",
-    "fp-ts": "^2.0.0"
+    "fp-ts": "^2.0.0",
+    "io-ts": "^2.0.0"
   },
   "jest": {
     "preset": "ts-jest"

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,10 +1,14 @@
 import * as fc from 'fast-check';
 import * as t from 'io-ts';
 import { getArbitrary, HasArbitrary } from '../src';
+import { date } from 'io-ts-types/lib/date';
+
+// pass
+const overrides = { Date: fc.date() };
 
 function test<T extends HasArbitrary>(codec: T): void {
   it(codec.name, () => {
-    fc.assert(fc.property(getArbitrary(codec), codec.is));
+    fc.assert(fc.property(getArbitrary(codec, overrides), codec.is));
   });
 }
 
@@ -27,3 +31,4 @@ test(t.intersection([t.type({ foo: t.string }), t.partial({ bar: t.number })]));
 test(t.intersection([t.type({ foo: t.string }), t.type({ bar: t.number })]));
 test(t.intersection([t.array(t.string), t.array(t.number)]));
 test(t.record(t.string, t.number));
+test(t.type({ date }));


### PR DESCRIPTION
Hi! Hope you're well. I'm trying to work out a way of generating arbitraries for stuff like the `date` codec from `io-ts-types`, and came up with this. Is this something you'd consider?

Thanks
Dan