### PR TITLE
Optional fallback arbitraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "fast-check-io-ts",
   "version": "0.5.0",
   "description": "io-ts codec to fast-check arbitrary mapping",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "repository": {
@@ -27,14 +25,7 @@
     "lint": "tslint -p tsconfig.json src/*.ts",
     "dtslint": "dtslint dtslint"
   },
-  "keywords": [
-    "fast-check",
-    "io-ts",
-    "typescript",
-    "arbitrary",
-    "generative",
-    "testing"
-  ],
+  "keywords": ["fast-check", "io-ts", "typescript", "arbitrary", "generative", "testing"],
   "author": "Giovanni Gonzaga <giovanni@buildo.io>",
   "license": "MIT",
   "devDependencies": {
@@ -49,7 +40,8 @@
     "rimraf": "^2.6.3",
     "ts-jest": "^24.0.2",
     "tslint": "^5.18.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.3",
+    "io-ts-types": "^0.5.6"
   },
   "peerDependencies": {
     "fast-check": ">=1.16.0",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,10 @@
 import * as fc from 'fast-check';
 import * as t from 'io-ts';
-import { getArbitrary, HasArbitrary } from '../src';
+import * as E from 'fp-ts/Either';
+import { getArbitrary, getArbitraryWithFallbacks, HasArbitrary } from '../src';
+import { date } from 'io-ts-types/lib/date';
+import { DateFromISOString } from 'io-ts-types/lib/DateFromISOString';
+import { DateFromUnixTime } from 'io-ts-types/lib/DateFromUnixTime';
 
 function test<T extends HasArbitrary>(codec: T): void {
   it(codec.name, () => {
@@ -27,3 +31,43 @@ test(t.intersection([t.type({ foo: t.string }), t.partial({ bar: t.number })]));
 test(t.intersection([t.type({ foo: t.string }), t.type({ bar: t.number })]));
 test(t.intersection([t.array(t.string), t.array(t.number)]));
 test(t.record(t.string, t.number));
+
+const overrides = { Date: fc.date(), DateFromISOString: fc.date() };
+
+function testWithFallbacks<T extends HasArbitrary>(codec: T): void {
+  it(`${codec.name} with fallbacks`, () => {
+    const eitherArbitrary = getArbitraryWithFallbacks(codec, overrides);
+    if (E.isLeft(eitherArbitrary)) {
+      throw new Error(`${eitherArbitrary.left}`);
+    }
+    fc.assert(fc.property((eitherArbitrary as E.Right<any>).right, codec.is));
+  });
+}
+
+testWithFallbacks(t.unknown);
+testWithFallbacks(t.undefined);
+testWithFallbacks(t.null);
+testWithFallbacks(t.string);
+testWithFallbacks(t.number);
+testWithFallbacks(t.boolean);
+testWithFallbacks(t.type({ foo: t.string, bar: t.number }));
+testWithFallbacks(t.partial({ foo: t.string, bar: t.number }));
+testWithFallbacks(t.union([t.undefined, t.string, t.type({ foo: t.string })]));
+testWithFallbacks(t.exact(t.type({ foo: t.string, bar: t.number })));
+testWithFallbacks(t.array(t.type({ foo: t.string })));
+testWithFallbacks(t.tuple([t.string, t.number, t.type({ foo: t.boolean })]));
+// @ts-ignore :(
+testWithFallbacks(t.keyof({ foo: null, bar: null }));
+testWithFallbacks(t.intersection([t.Int, t.number]));
+testWithFallbacks(t.intersection([t.type({ foo: t.string }), t.partial({ bar: t.number })]));
+testWithFallbacks(t.intersection([t.type({ foo: t.string }), t.type({ bar: t.number })]));
+testWithFallbacks(t.intersection([t.array(t.string), t.array(t.number)]));
+testWithFallbacks(t.record(t.string, t.number));
+testWithFallbacks(t.type({ date }));
+testWithFallbacks(t.type({ date: DateFromISOString }));
+
+it(`Returns Left with error when fallback cannot be found`, () => {
+  const codec = t.type({ name: DateFromUnixTime });
+  const eitherArbitrary = getArbitraryWithFallbacks(codec, overrides);
+  expect(E.isLeft(eitherArbitrary)).toBeTruthy();
+});


### PR DESCRIPTION
This is the belated sequel to #1 

Removes use of errors and introduces the `t.Any` type to the codecs it accepts so that TS will accept custom codecs like from `io-ts-types`.

Currently implemented as a separate function but happy to combine into one overloaded top-level function if that makes more sense for consumers.